### PR TITLE
feature/filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ const defaultOptions = {
      */
     includeContextKeys: [],
   },
+
+  /**
+   * Provide a callback function which receives an instance of this package's Operation class
+   * Only operations that pass the test are sent to Sentry. Leave undefined if you want all
+   * operations to pass. See PR #9 for more details.
+   */
+  filter: (operation) => true,
 };
 ```
 
@@ -147,8 +154,9 @@ Furthermore, much of the data you are sending to Sentry can include (sensitive) 
 
 ## Roadmap / notes
 - Add the possibility to exclude:
-  - Operations
-  - URLs?
+  - data through a custom beforeBreadcrumb
+- Provide wrapper for Sentry's beforeBreadcrumb to filter out fetch requests
+  - Caveat: people using `unfetch`?
 - Write best practice scenario:
   - setting `includeError` true
   - catch errors manually

--- a/src/OperationsBreadcrumb.ts
+++ b/src/OperationsBreadcrumb.ts
@@ -19,6 +19,7 @@ export namespace Breadcrumb {
 }
 
 export class OperationsBreadcrumb {
+  public filtered: boolean;
   public flushed: boolean;
   private readonly breadcrumb: Breadcrumb.Data;
 
@@ -26,6 +27,7 @@ export class OperationsBreadcrumb {
    * Start a new ApolloLinkSentry Breadcrumb
    */
   constructor() {
+    this.filtered = false;
     this.flushed = false;
     this.breadcrumb = {};
 
@@ -168,6 +170,15 @@ export class OperationsBreadcrumb {
     };
 
     return this;
+  };
+
+  /**
+   * The filter option can ensure some operations are not sent to Sentry
+   * @returns {boolean}
+   */
+  filter = (toggle: boolean): boolean => {
+    this.filtered = !toggle;
+    return !toggle;
   };
 
   /**


### PR DESCRIPTION
Allows for filtering by setting option `filter`. Implement like this:

```js

{
  filter: (operation) => {
    // Exclude MeQuery operations from the breadcrumbs
    return operation.name !== 'MeQuery';
  }
}
```