### PR TITLE
refactor: public breadcrumb

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,18 @@ export const isEmpty = (target?: object): boolean => (
 export const stringifyObject = (target: any): string => (
   JSON.stringify(target, null, 2)
 );
+
+/**
+ * Omit empty values from an object
+ * @param target
+ */
+export const trimObject = (target: any): object => {
+  if (isEmpty(target)) return {};
+
+  return Object.keys(target)
+    .filter((key: string) => target?.[key])
+    .reduce((a: object, key: string): object => ({
+      ...a,
+      [key]: target[key],
+    }), {});
+};

--- a/tests/OperationsBreadcrumb.test.ts
+++ b/tests/OperationsBreadcrumb.test.ts
@@ -7,7 +7,7 @@ jest.mock('../src/Operation');
 
 describe('OperationBreadcrumb', () => {
   it('should set defaults when creating a new breadcrumb', () => {
-    const { category, level } = new OperationBreadcrumb()['breadcrumb'];
+    const { category, level } = new OperationBreadcrumb();
 
     expect(level).toBe(Severity.Log); // The default log level
     expect(category).toBe('gql'); // The default category
@@ -15,28 +15,28 @@ describe('OperationBreadcrumb', () => {
 
   it('should be possible to set the level', () => {
     const breadcrumb = new OperationBreadcrumb();
-    const { level } = breadcrumb.setLevel(Severity.Error)['breadcrumb'];
+    const { level } = breadcrumb.setLevel(Severity.Error);
 
     expect(level).toBe(Severity.Error);
   });
 
   it('should be possible to set the category', () => {
     const breadcrumb = new OperationBreadcrumb();
-    const { category } = breadcrumb.setCategory('query')['breadcrumb'];
+    const { category } = breadcrumb.setCategory('query');
 
     expect(category).toBe('gql query'); // The category is prefixed with 'gql'
   });
 
   it('should be possible to set the type', () => {
     const breadcrumb = new OperationBreadcrumb();
-    const { type } = breadcrumb.setType('error')['breadcrumb'];
+    const { type } = breadcrumb.setType('error');
 
     expect(type).toBe('error');
   });
 
   it('should be possible to set the message', () => {
     const breadcrumb = new OperationBreadcrumb();
-    const { message } = breadcrumb.setMessage('TestQuery')['breadcrumb'];
+    const { message } = breadcrumb.setMessage('TestQuery');
 
     expect(message).toBe('TestQuery');
   });
@@ -51,7 +51,7 @@ describe('OperationBreadcrumb', () => {
     };
 
     const breadcrumb = new OperationBreadcrumb();
-    const { data } = breadcrumb.setCache(cache)['breadcrumb'];
+    const data = breadcrumb.setCache(cache);
 
     expect(data?.cache).toBe(stringifyObject(cache));
   });
@@ -60,7 +60,7 @@ describe('OperationBreadcrumb', () => {
     const variables = { name: 'TestName' };
 
     const breadcrumb = new OperationBreadcrumb();
-    const { data } = breadcrumb.setVariables(variables)['breadcrumb'];
+    const data = breadcrumb.setVariables(variables);
 
     expect(data?.variables).toBe(stringifyObject(variables));
   });
@@ -69,7 +69,7 @@ describe('OperationBreadcrumb', () => {
     const context = { headers: { 'X-Debug': true } };
 
     const breadcrumb = new OperationBreadcrumb();
-    const { data } = breadcrumb.setContext(context)['breadcrumb'];
+    const data = breadcrumb.setContext(context);
 
     expect(data?.context).toBe(stringifyObject(context));
   });
@@ -78,7 +78,7 @@ describe('OperationBreadcrumb', () => {
     const response = { status: 200, data: { success: true } };
 
     const breadcrumb = new OperationBreadcrumb();
-    const { data } = breadcrumb.setResponse(response)['breadcrumb'];
+    const data = breadcrumb.setResponse(response);
 
     expect(data?.response).toBe(stringifyObject(response));
   });
@@ -87,7 +87,7 @@ describe('OperationBreadcrumb', () => {
     const error = { status: 401, data: { error: 'Unauthorized' } };
 
     const breadcrumb = new OperationBreadcrumb();
-    const { data } = breadcrumb.setError(error)['breadcrumb'];
+    const data = breadcrumb.setError(error);
 
     expect(data?.error).toBe(stringifyObject(error));
   });

--- a/tests/SentryLink.test.ts
+++ b/tests/SentryLink.test.ts
@@ -52,11 +52,11 @@ describe('SentryLink', () => {
 
     link.fillBreadcrumb(breadcrumb, operation);
 
-    expect(breadcrumb['breadcrumb'].message).toBe(operation.name);
-    expect(breadcrumb['breadcrumb'].category).toBe(`gql ${operation.type}`);
-    expect(breadcrumb['breadcrumb'].data?.query).toBe(operation.query);
-    expect(breadcrumb['breadcrumb'].data?.cache).toBe(stringifyObject(operation.cache));
-    expect(breadcrumb['breadcrumb'].data?.variables).toBe(stringifyObject(operation.variables));
+    expect(breadcrumb.message).toBe(operation.name);
+    expect(breadcrumb.category).toBe(`gql ${operation.type}`);
+    expect(breadcrumb.query).toBe(operation.query);
+    expect(breadcrumb.cache).toBe(stringifyObject(operation.cache));
+    expect(breadcrumb.variables).toBe(stringifyObject(operation.variables));
   });
 
   test('should attach a sentry breadcrumb for an operation', (done) => {
@@ -165,7 +165,7 @@ describe('SentryLink', () => {
 
       link.fillBreadcrumb(breadcrumb, operation);
 
-      expect(breadcrumb['breadcrumb'].data?.query).toBeUndefined();
+      expect(breadcrumb.query).toBeUndefined();
     });
 
     test('should not attach the variables if the option is disabled', () => {
@@ -175,7 +175,7 @@ describe('SentryLink', () => {
 
       link.fillBreadcrumb(breadcrumb, operation);
 
-      expect(breadcrumb['breadcrumb'].data?.variables).toBeUndefined();
+      expect(breadcrumb.variables).toBeUndefined();
     });
 
     test('should not attach the apollo cache if the option is disabled', () => {
@@ -185,7 +185,7 @@ describe('SentryLink', () => {
 
       link.fillBreadcrumb(breadcrumb, operation);
 
-      expect(breadcrumb['breadcrumb'].data?.cache).toBeUndefined();
+      expect(breadcrumb.cache).toBeUndefined();
     });
 
     test('should not attach the response data if the option is disabled', (done) => {


### PR DESCRIPTION
fix: allows reading data from `OperationBreadcrumb`

> Supports the new `beforeBreadcrumb` option

chore: adds back trimObject util