### PR TITLE
feat: Use sentry minimal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
     "deploy": "yarn publish --non-interactive"
   },
   "dependencies": {
-    "@sentry/browser": "^5.15.5",
+    "@sentry/minimal": "^5.15.5",
     "@sentry/types": "^5.15.4",
     "apollo-link": "^1.2.14",
     "deepmerge": "^4.2.2",
     "dot-prop": "^5.2.0",
-    "graphql": "^14.6.0"
+    "tslib": "^1.11.1"
   },
   "devDependencies": {
+    "graphql": "^14.6.0",
     "@types/jest": "^25.1.5",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.29.0",
@@ -50,6 +51,7 @@
     "standard-version": "^7.1.0",
     "ts-jest": "^25.4.0",
     "tsc-watch": "~4.2.3",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "@sentry/browser": "^5.15.5"
   }
 }

--- a/src/OperationBreadcrumb.ts
+++ b/src/OperationBreadcrumb.ts
@@ -1,5 +1,4 @@
-import { Severity } from '@sentry/browser';
-import { Breadcrumb as SentryBreadcrumb } from '@sentry/types';
+import { Breadcrumb as SentryBreadcrumb, Severity } from '@sentry/types';
 
 import { isEmpty, stringifyObject, trimObject } from './utils';
 

--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/browser';
 import { Scope, Severity } from '@sentry/types';
 import deepMerge from 'deepmerge';
 
@@ -7,6 +6,7 @@ import {
   ApolloLink, NextLink, Observable, Operation as ApolloOperation,
 } from 'apollo-link';
 
+import { addBreadcrumb, configureScope } from '@sentry/minimal';
 import { OperationBreadcrumb } from './OperationBreadcrumb';
 import { Operation } from './Operation';
 
@@ -181,7 +181,7 @@ export class SentryLink extends ApolloLink {
    * @param {Operation} operation
    */
   setTransaction = (operation: Operation): void => {
-    Sentry.configureScope((scope: Scope) => {
+    configureScope((scope: Scope) => {
       scope.setTransaction(operation.name);
     });
   };
@@ -190,7 +190,7 @@ export class SentryLink extends ApolloLink {
    * Set the Sentry fingerprint
    */
   setFingerprint = (): void => {
-    Sentry.configureScope((scope: Scope) => {
+    configureScope((scope: Scope) => {
       scope.setFingerprint([
         '{{default}}',
         '{{transaction}}',
@@ -214,10 +214,10 @@ export class SentryLink extends ApolloLink {
 
     if (typeof this.options.beforeBreadcrumb === 'function') {
       const after = this.options.beforeBreadcrumb(breadcrumb);
-      Sentry.addBreadcrumb(after.flush());
+      addBreadcrumb(after.flush());
       return;
     }
 
-    Sentry.addBreadcrumb(breadcrumb.flush());
+    addBreadcrumb(breadcrumb.flush());
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,7 +477,7 @@
     "@sentry/utils" "5.15.5"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.15.5":
+"@sentry/minimal@5.15.5", "@sentry/minimal@^5.15.5":
   version "5.15.5"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.5.tgz#a0e4e071f01d9c4d808094ae7203f6c4cca9348a"
   integrity sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==
@@ -5497,7 +5497,7 @@ tsc-watch@~4.2.3:
     string-argv "^0.1.1"
     strip-ansi "^4.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
With this PR I aim to move the lib from using `browser` to using `minimal`.

Sentry gives us this minimal package to purely instrument libraries and alike that disjoints it from what a potential runtime might be. As in my case, I SSR apollo, and `browser` simply wont work there.

**Changes**
- added tslib as a dependency, seeing as `tsc` is used to build, the class extend's utilizes a tslib helper for this in jsland, so the produced output would depend on tslib. Which may/maynot exist in consumer code.
- moved graphql dep to a devDependencies because afaik it isn't a dependency of the code itself, but rather the unit tests.
- moved `@sentry/browser` as a devDependencies, as its _only_ used in unit tests now

---

I will also like to note that ideally id love to remove the need to even run browser in the unit tests, and briefly looked at using `@sentry/hub` and `@sentry/core` and build a test client, kinda what `sentry-testkit` does; but without needing to `init`.

Because `minimal` simply adds stuff to the current hub, so was thinking perhaps we can tap into this. But will discuss/do this in another pr