### PR TITLE
move to newer style imports

### DIFF
--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -1,4 +1,4 @@
-import { Operation as ApolloOperation } from '@apollo/client/link/core';
+import { Operation as ApolloOperation } from '@apollo/client';
 import dotProp from 'dot-prop';
 
 import { isEmpty } from './utils';

--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -6,7 +6,7 @@ import { FetchResult } from '@apollo/client';
 
 import {
   ApolloLink, NextLink, Operation as ApolloOperation,
-} from '@apollo/client/link/core';
+} from '@apollo/client';
 
 import { addBreadcrumb, configureScope } from '@sentry/minimal';
 import { OperationBreadcrumb } from './OperationBreadcrumb';

--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -2,7 +2,7 @@ import { Scope, Severity } from '@sentry/types';
 import deepMerge from 'deepmerge';
 import Observable from 'zen-observable';
 
-import { FetchResult } from '@apollo/client/link/core/types';
+import { FetchResult } from '@apollo/client';
 
 import {
   ApolloLink, NextLink, Operation as ApolloOperation,


### PR DESCRIPTION
move to newer style imports because existing imports dont work for some Apollo 3 versions. and any way, they are better looking : )