### PR TITLE
Add helpers to exclude GraphQL fetch breadcrumbs

### DIFF
--- a/src/excludeGraphQLFetch.ts
+++ b/src/excludeGraphQLFetch.ts
@@ -1,0 +1,28 @@
+import { BrowserOptions } from '@sentry/browser';
+
+type BeforeBreadcrumbCallback = NonNullable<BrowserOptions['beforeBreadcrumb']>;
+
+export const excludeGraphQLFetch: BeforeBreadcrumbCallback = (breadcrumb) => {
+  if (breadcrumb.category === 'fetch') {
+    const url: string = breadcrumb.data?.url ?? '';
+
+    if (url.includes('/graphql')) {
+      return null;
+    }
+  }
+
+  return breadcrumb;
+};
+
+export const withoutGraphQLFetch = (
+  beforeBreadcrumb: BeforeBreadcrumbCallback
+): BeforeBreadcrumbCallback => {
+  return (breadcrumb, hint) => {
+    const withoutFetch = excludeGraphQLFetch(breadcrumb, hint);
+    if (withoutFetch === null) {
+      return null;
+    }
+
+    return beforeBreadcrumb(withoutFetch, hint);
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Operation } from './Operation';
+export * from './excludeGraphQLFetch';
 export * from './SentryLink';

--- a/tests/excludeGraphQLFetch.test.ts
+++ b/tests/excludeGraphQLFetch.test.ts
@@ -1,0 +1,56 @@
+import { excludeGraphQLFetch, withoutGraphQLFetch } from '../src';
+
+describe('excludeGraphQLFetch', () => {
+  it('should remove fetch operations on GraphQL endpoints', () => {
+    expect(
+      excludeGraphQLFetch({
+        category: 'fetch',
+        data: { url: 'https://example.com/graphql' },
+      })
+    ).toBeNull();
+  });
+
+  it('should leave non-GraphQL fetches', () => {
+    const breadcrumb = {
+      category: 'fetch',
+      data: { url: 'https://example.com' },
+    };
+    expect(excludeGraphQLFetch(breadcrumb)).toEqual(breadcrumb);
+  });
+
+  it('should leave non-fetch breadcrumbs', () => {
+    const breadcrumb = { category: 'not-fetch' };
+    expect(excludeGraphQLFetch(breadcrumb)).toEqual(breadcrumb);
+  });
+});
+
+describe('withoutGraphQLFetch', () => {
+  it('should wrap custom callback and short circuit when filtering out fetches', () => {
+    const callback = jest.fn();
+
+    const wrapped = withoutGraphQLFetch(callback);
+
+    expect(
+      wrapped({
+        category: 'fetch',
+        data: { url: 'https://example.com/graphql' },
+      })
+    ).toBeNull();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should pass non-fetches and the hint along to callback', () => {
+    const initial = { category: 'not-fetch' };
+    const hint = { foo: 'bar' };
+
+    const callback = jest.fn();
+    const altered = { category: 'altered' };
+    callback.mockReturnValue(altered);
+
+    const wrapped = withoutGraphQLFetch(callback);
+
+    expect(wrapped(initial, hint)).toEqual(altered);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(initial, hint);
+  });
+});


### PR DESCRIPTION
As suggested in the roadmap, those helpers ease filtering duplicate breadcrumbs.