### PR TITLE
Improve breadcrumb data serialization and handling of ServerError.result

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,9 @@ module.exports = {
       { 'newlines-between': 'always', alphabetize: { order: 'asc' } },
     ],
     'import/prefer-default-export': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { ignoreRestSiblings: true },
+    ],
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,6 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-  // All imported modules in your tests should be mocked automatically
-  // automock: false,
-
   // Automatically clear mock calls and instances between every test
   clearMocks: false,
 
@@ -16,50 +13,14 @@ module.exports = {
   // The directory where Jest should output its coverage files
   coverageDirectory: 'tests/coverage',
 
-  // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
-
-  // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
-
-  // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
-
-  // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
-
-  // Automatically reset mock state between every test
-  // resetMocks: false,
-
-  // Automatically restore mock state between every test
-  // restoreMocks: false,
-
   // Make calling deprecated APIs throw helpful error messages
   errorOnDeprecated: true,
 
   // Use this configuration option to add custom reporters to Jest
   reporters: ['jest-spec-reporter'],
 
-  // The root directory that Jest should scan for tests and modules within
-  // rootDir: './tests',
-
-  // Adds a location field to test results
-  // testLocationInResults: false,
-
-  // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  // A list of paths to modules that run some code to configure or set up the testing environment
+  setupFiles: ['./tests/setup.ts'],
 
   // A map from regular expressions to paths to transformers
   transform: {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
     "graphql": "^15.4.0",
+    "isomorphic-fetch": "^3.0.0",
     "jest": "^26.5.3",
     "jest-spec-reporter": "^1.0.14",
     "prettier": "^2.2.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,15 @@
+export function stringifyObjectKeys(
+  object: Record<string, unknown>,
+): Record<string, unknown> {
+  const stringified: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(object)) {
+    stringified[key] = typeof value === 'object' ? stringify(value) : value;
+  }
+
+  return stringified;
+}
+
+export function stringify(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}

--- a/tests/SentryLink.test.ts
+++ b/tests/SentryLink.test.ts
@@ -7,6 +7,7 @@ import Observable from 'zen-observable';
 
 import { GraphQLBreadcrumb, SentryLink, SentryLinkOptions } from '../src';
 import { DEFAULT_FINGERPRINT } from '../src/sentry';
+import { stringify } from '../src/utils';
 
 const { testkit, sentryTransport } = sentryTestkit();
 
@@ -103,14 +104,14 @@ describe('SentryLink', () => {
             expect(success.category).toBe('graphql.query');
             expect(success.level).toBe(Severity.Info);
             expect(success.data.operationName).toBe('SuccessQuery');
-            expect(success.data.fetchResult).toStrictEqual(result);
+            expect(success.data.fetchResult).toBe(stringify(result));
             expect(success.data).not.toHaveProperty('error');
 
             expect(failure.category).toBe('graphql.mutation');
             expect(failure.level).toBe(Severity.Error);
             expect(failure.data.operationName).toBe('FailureMutation');
             expect(failure.data).not.toHaveProperty('result');
-            expect(failure.data.error?.message).toEqual(error.message);
+            expect(failure.data.error).toBe(stringify(error));
 
             done();
           },

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,2 @@
+// Allows using the Response object
+import 'isomorphic-fetch';

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,21 @@
+import { stringifyObjectKeys } from '../src/utils';
+
+describe('stringifyObjectKeys', () => {
+  it('stringifies all keys that are objects', () => {
+    expect(
+      stringifyObjectKeys({
+        string: 'foo',
+        number: 3,
+        boolean: true,
+        object: { a: 'a' },
+      }),
+    ).toEqual({
+      string: 'foo',
+      number: 3,
+      boolean: true,
+      object: `{
+  "a": "a"
+}`,
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -4167,6 +4175,11 @@ node-cleanup@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5998,6 +6011,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
+  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Resolves https://github.com/DiederikvandenB/apollo-link-sentry/issues/278

The first part towards solving this issue is recognizing when a thrown error includes a result. I think the correct thing to do in that case is to respect the value of the `includeFetchResult` configuration and act accordingly.

The second part would be to do deep serialization of certain parts of the breadcrumb. I am not quite sure how that is best handled, especially when considering `attachBreadcrumbs.transform` - this function expects a breadcrumb that still holds structured data, that should be the most useful to work with. Should we just JSON-stringify every key of the transformed breadcrumb afterwards?