### PR TITLE
fix: include errors in breadcrumbs starting with the first

### DIFF
--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -67,9 +67,9 @@ export class SentryLink extends ApolloLink {
             if (
               this.options.attachBreadcrumbs.includeError &&
               result.errors &&
-              result.errors.length > 1
+              result.errors.length > 0
             ) {
-              // We must have a breadcrumb if attachBreadcrumbs was set
+              // Include any errors if the option is set
               (breadcrumb as GraphQLBreadcrumb).data.error = new ApolloError({
                 graphQLErrors: result.errors,
               });

--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -69,7 +69,7 @@ export class SentryLink extends ApolloLink {
               result.errors &&
               result.errors.length > 0
             ) {
-              // Include any errors if the option is set
+              // We must have a breadcrumb if attachBreadcrumbs was set
               (breadcrumb as GraphQLBreadcrumb).data.error = new ApolloError({
                 graphQLErrors: result.errors,
               });


### PR DESCRIPTION
I've added a test that in my opinion should pass, but doesn't. I would expect graphQLErrors to be populated in the breadcrumb if includeErrors is set to true, but it is undefined. The test is almost identical to this test that was added yesterday in #410 , except that it only contains one error.

https://github.com/DiederikvandenB/apollo-link-sentry/blob/8b90e7a1abe88ae66126aa4971ed0da4ae16b190/tests/SentryLink.test.ts#L126-L170

I don't see why the logic should kick in only when at least 2 gql errors are encountered: https://github.com/DiederikvandenB/apollo-link-sentry/pull/410/files/606c5df1cbee73a5391ce2d36b85bd0370f83f3e#r771429756
