### PR TITLE
docs: fix option name reference (includeContext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ export type AttachBreadcrumbsOptions = {
    * Modify the breadcrumb right before it is sent.
    *
    * Can be used to add additional data from the operation or clean up included data.
-   * Very useful in combination with options like `includeVariables` and `includeContextKeys`.
+   * Very useful in combination with options like `includeVariables` and `includeContext`.
    *
    * Defaults to undefined.
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -115,7 +115,7 @@ export type AttachBreadcrumbsOptions = {
    * Modify the breadcrumb right before it is sent.
    *
    * Can be used to add additional data from the operation or clean up included data.
-   * Very useful in combination with options like `includeVariables` and `includeContextKeys`.
+   * Very useful in combination with options like `includeVariables` and `includeContext`.
    *
    * Defaults to undefined.
    */


### PR DESCRIPTION
I noticed that the docs referenced `includeContextKeys` which seems not to exist, changed it to match existing option `includeContext`