### PR TITLE
fix: use zen-observable-ts over zen-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deepmerge": "^4.2.2",
     "dot-prop": "^6.0.0",
     "tslib": "^2.0.3",
-    "zen-observable": "^0.8.15"
+    "zen-observable-ts": "^1.2.5"
   },
   "peerDependencies": {
     "@apollo/client": "^3.2.3",
@@ -45,7 +45,6 @@
     "@semantic-release/git": "^10.0.1",
     "@sentry/browser": "^7.0.0",
     "@types/jest": "^27.0.3",
-    "@types/zen-observable": "^0.8.3",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
     "eslint": "^8.4.1",

--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -7,7 +7,7 @@ import {
   ServerError,
 } from '@apollo/client/core';
 import type { SeverityLevel } from '@sentry/types';
-import Observable from 'zen-observable';
+import { Observable } from 'zen-observable-ts';
 
 import { GraphQLBreadcrumb, makeBreadcrumb } from './breadcrumb';
 import { FullOptions, SentryLinkOptions, withDefaults } from './options';

--- a/tests/SentryLink.test.ts
+++ b/tests/SentryLink.test.ts
@@ -7,7 +7,7 @@ import {
 import * as Sentry from '@sentry/browser';
 import { GraphQLError, parse } from 'graphql';
 import sentryTestkit from 'sentry-testkit';
-import Observable from 'zen-observable';
+import { Observable } from 'zen-observable-ts';
 
 import { GraphQLBreadcrumb, SentryLink, SentryLinkOptions } from '../src';
 import { DEFAULT_FINGERPRINT } from '../src/sentry';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,11 +1129,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/zen-observable@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
-
 "@typescript-eslint/eslint-plugin@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.7.0.tgz#12d54709f8ea1da99a01d8a992cd0474ad0f0aa9"
@@ -6712,7 +6707,14 @@ zen-observable-ts@^1.2.0:
   dependencies:
     zen-observable "0.8.15"
 
-zen-observable@0.8.15, zen-observable@^0.8.15:
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Fixes missing type definitions when using this package from TypeScript.

Resolves https://github.com/DiederikvandenB/apollo-link-sentry/issues/449