### PR TITLE
feat: add tracing spans for GraphQL operations

### DIFF
--- a/src/SentryLink.ts
+++ b/src/SentryLink.ts
@@ -7,9 +7,11 @@ import {
   ServerError,
 } from '@apollo/client/core';
 import type { SeverityLevel } from '@sentry/core';
+import { startSpan } from '@sentry/core';
 import { Observable } from 'zen-observable-ts';
 
 import { makeBreadcrumb } from './breadcrumb';
+import { extractDefinition } from './operation';
 import { FullOptions, SentryLinkOptions, withDefaults } from './options';
 import {
   attachBreadcrumbToSentry,
@@ -45,6 +47,10 @@ export class SentryLink extends ApolloLink {
 
     const { attachBreadcrumbs } = options;
     if (!attachBreadcrumbs) {
+      if (options.tracing) {
+        return this.withSpan(operation, forward);
+      }
+
       return forward(operation);
     }
 
@@ -56,61 +62,103 @@ export class SentryLink extends ApolloLink {
     // get to run our instrumentation before others observers potentially
     // throw and thus flush the results to Sentry.
     return new Observable<FetchResult>((originalObserver) => {
-      const subscription = forward(operation).subscribe({
-        next: (result) => {
-          breadcrumb.level = severityForResult(result);
+      const spanOptions = options.tracing
+        ? spanOptionsForOperation(operation)
+        : undefined;
 
-          if (attachBreadcrumbs.includeFetchResult) {
-            breadcrumb.data.fetchResult = result;
-          }
-
-          if (
-            attachBreadcrumbs.includeError &&
-            result.errors &&
-            result.errors.length > 0
-          ) {
-            breadcrumb.data.error = new ApolloError({
-              graphQLErrors: result.errors,
-            });
-          }
-
-          originalObserver.next(result);
-        },
-        complete: () => {
-          attachBreadcrumbToSentry(operation, breadcrumb, options);
-
-          originalObserver.complete();
-        },
-        error: (error) => {
-          breadcrumb.level = 'error';
-
-          let scrubbedError;
-          if (isServerError(error)) {
-            const { result, response, ...rest } = error;
-            scrubbedError = rest;
+      const execute = () => {
+        const subscription = forward(operation).subscribe({
+          next: (result) => {
+            breadcrumb.level = severityForResult(result);
 
             if (attachBreadcrumbs.includeFetchResult) {
               breadcrumb.data.fetchResult = result;
             }
-          } else {
-            scrubbedError = error;
-          }
 
-          if (attachBreadcrumbs.includeError) {
-            breadcrumb.data.error = scrubbedError;
-          }
+            if (
+              attachBreadcrumbs.includeError &&
+              result.errors &&
+              result.errors.length > 0
+            ) {
+              breadcrumb.data.error = new ApolloError({
+                graphQLErrors: result.errors,
+              });
+            }
 
-          attachBreadcrumbToSentry(operation, breadcrumb, options);
+            originalObserver.next(result);
+          },
+          complete: () => {
+            attachBreadcrumbToSentry(operation, breadcrumb, options);
 
-          originalObserver.error(error);
-        },
-      });
+            originalObserver.complete();
+          },
+          error: (error) => {
+            breadcrumb.level = 'error';
 
-      return () => {
-        subscription.unsubscribe();
+            let scrubbedError;
+            if (isServerError(error)) {
+              const { result, response, ...rest } = error;
+              scrubbedError = rest;
+
+              if (attachBreadcrumbs.includeFetchResult) {
+                breadcrumb.data.fetchResult = result;
+              }
+            } else {
+              scrubbedError = error;
+            }
+
+            if (attachBreadcrumbs.includeError) {
+              breadcrumb.data.error = scrubbedError;
+            }
+
+            attachBreadcrumbToSentry(operation, breadcrumb, options);
+
+            originalObserver.error(error);
+          },
+        });
+
+        return () => {
+          subscription.unsubscribe();
+        };
       };
+
+      if (spanOptions) {
+        return startSpan(spanOptions, execute);
+      }
+
+      return execute();
     });
   }
+
+  private withSpan(
+    operation: Operation,
+    forward: NextLink,
+  ): Observable<FetchResult> {
+    return new Observable<FetchResult>((observer) => {
+      return startSpan(spanOptionsForOperation(operation), () => {
+        const subscription = forward(operation).subscribe(observer);
+
+        return () => {
+          subscription.unsubscribe();
+        };
+      });
+    });
+  }
+}
+
+function spanOptionsForOperation(operation: Operation) {
+  const definition = extractDefinition(operation);
+  const type = definition.operation;
+  const name = definition.name?.value ?? 'anonymous';
+
+  return {
+    name: `graphql.${type} ${name}`,
+    op: 'graphql',
+    attributes: {
+      'graphql.operation.type': type,
+      'graphql.operation.name': name,
+    },
+  };
 }
 
 function isServerError(error: unknown): error is ServerError {

--- a/src/options.ts
+++ b/src/options.ts
@@ -54,6 +54,17 @@ export interface FullOptions {
    * }
    */
   attachBreadcrumbs: AttachBreadcrumbsOptions | false;
+
+  /**
+   * Create a Sentry span for each GraphQL operation.
+   *
+   * When enabled, a child span is started for each operation and finished
+   * when the operation completes or errors. This provides timing data
+   * in your Sentry performance traces.
+   *
+   * Defaults to true.
+   */
+  tracing: true | false;
 }
 
 export type AttachBreadcrumbsOptions = {
@@ -140,6 +151,8 @@ export const defaultOptions = {
     includeContext: false,
     transform: undefined,
   },
+
+  tracing: true,
 } as const;
 
 export function withDefaults(options: SentryLinkOptions): FullOptions {
@@ -149,7 +162,11 @@ export function withDefaults(options: SentryLinkOptions): FullOptions {
 export type SentryLinkOptions = Partial<
   Pick<
     FullOptions,
-    'shouldHandleOperation' | 'uri' | 'setTransaction' | 'setFingerprint'
+    | 'shouldHandleOperation'
+    | 'uri'
+    | 'setTransaction'
+    | 'setFingerprint'
+    | 'tracing'
   >
 > & {
   attachBreadcrumbs?: Partial<AttachBreadcrumbsOptions> | false;

--- a/tests/SentryLink.test.ts
+++ b/tests/SentryLink.test.ts
@@ -14,6 +14,7 @@ import sentryTestkit from 'sentry-testkit';
 import { GraphQLBreadcrumb, SentryLink, SentryLinkOptions } from '../src';
 import { DEFAULT_FINGERPRINT } from '../src/sentry';
 import { stringify } from '../src/utils';
+
 import { createApolloClient } from './utils';
 
 const mockSpan = { end: jest.fn() } as unknown as Span;
@@ -486,7 +487,11 @@ describe('SentryLink', () => {
 
     const link = ApolloLink.from([new SentryLink({ tracing: true }), nullLink]);
 
-    execute(link, { query: parse(`query TracedQuery { foo }`) }, context).subscribe({
+    execute(
+      link,
+      { query: parse(`query TracedQuery { foo }`) },
+      context,
+    ).subscribe({
       complete: () => {
         expect(startSpanManualMock).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -539,7 +544,11 @@ describe('SentryLink', () => {
       nullLink,
     ]);
 
-    execute(link, { query: parse(`query UntracedQuery { foo }`) }, context).subscribe({
+    execute(
+      link,
+      { query: parse(`query UntracedQuery { foo }`) },
+      context,
+    ).subscribe({
       complete: () => {
         expect(startSpanManualMock).not.toHaveBeenCalled();
 

--- a/tests/SentryLink.test.ts
+++ b/tests/SentryLink.test.ts
@@ -5,6 +5,7 @@ import {
   ServerError,
 } from '@apollo/client/core';
 import * as Sentry from '@sentry/browser';
+import { startSpan } from '@sentry/core';
 import { GraphQLError, parse } from 'graphql';
 import sentryTestkit from 'sentry-testkit';
 import { Observable } from 'zen-observable-ts';
@@ -12,6 +13,16 @@ import { Observable } from 'zen-observable-ts';
 import { GraphQLBreadcrumb, SentryLink, SentryLinkOptions } from '../src';
 import { DEFAULT_FINGERPRINT } from '../src/sentry';
 import { stringify } from '../src/utils';
+
+jest.mock('@sentry/core', () => ({
+  ...jest.requireActual('@sentry/core'),
+  startSpan: jest.fn(
+    (_options: unknown, callback: (...args: unknown[]) => unknown) =>
+      callback(),
+  ),
+}));
+
+const startSpanMock = startSpan as jest.MockedFunction<typeof startSpan>;
 
 const { testkit, sentryTransport } = sentryTestkit();
 
@@ -435,6 +446,47 @@ describe('SentryLink', () => {
         const [breadcrumb] = report.breadcrumbs;
 
         expect(breadcrumb.data?.foo).toBe('Foo');
+
+        done();
+      },
+    });
+  });
+
+  it('should create a span when tracing is enabled', (done) => {
+    startSpanMock.mockClear();
+
+    const link = ApolloLink.from([new SentryLink({ tracing: true }), nullLink]);
+
+    execute(link, { query: parse(`query TracedQuery { foo }`) }).subscribe({
+      complete: () => {
+        expect(startSpanMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'graphql.query TracedQuery',
+            op: 'graphql',
+            attributes: {
+              'graphql.operation.type': 'query',
+              'graphql.operation.name': 'TracedQuery',
+            },
+          }),
+          expect.any(Function),
+        );
+
+        done();
+      },
+    });
+  });
+
+  it('should not create a span when tracing is disabled', (done) => {
+    startSpanMock.mockClear();
+
+    const link = ApolloLink.from([
+      new SentryLink({ tracing: false }),
+      nullLink,
+    ]);
+
+    execute(link, { query: parse(`query UntracedQuery { foo }`) }).subscribe({
+      complete: () => {
+        expect(startSpanMock).not.toHaveBeenCalled();
 
         done();
       },


### PR DESCRIPTION
## Summary

- Adds a `tracing` option (default: `true`) that creates a Sentry span for each GraphQL operation
- Uses the modern `startSpan` API from `@sentry/core` (v8+/v9+/v10+)
- Spans are named `graphql.<type> <operationName>` with semantic attributes (`graphql.operation.type`, `graphql.operation.name`)
- Works independently of breadcrumbs — tracing works even with `attachBreadcrumbs: false`

This supersedes #265, which targeted the legacy `transaction.startChild()` API that no longer exists in modern Sentry SDKs.

## Usage

Tracing is enabled by default. To disable:

```ts
new SentryLink({ tracing: false })
```

## Test plan

- [x] Existing 30 tests still pass
- [x] New test verifies `startSpan` is called with correct span options
- [x] New test verifies `startSpan` is NOT called when tracing is disabled
- [x] Build passes cleanly

🤖 Generated with Claude Code