### PR TITLE
fix(ci): don't fail builds on Coveralls upload errors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,7 @@ jobs:
     - run: yarn run test:coverage
 
     - uses: coverallsapp/github-action@v2
+      continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the Coveralls upload step
- Coveralls returns "Unprocessable Entity" for fork PRs, blocking CI even when all tests pass
- Coverage reporting is informational and should not gate mergeability

## Test plan

- [ ] CI passes on this PR
- [ ] Verify on a fork PR (e.g. #477) that Coveralls failure no longer blocks

🤖 Generated with Claude Code